### PR TITLE
Make list route configurable via manifest

### DIFF
--- a/example_applications/simple_entity/Simple-RecordSet-Application.js
+++ b/example_applications/simple_entity/Simple-RecordSet-Application.js
@@ -490,7 +490,7 @@ module.exports.default_configuration.pict_configuration = (
 				"RecordSetType": "MeadowEndpoint", // Could be "Custom" which would require a provider to already be created for the record set.
 				"RecordSetMeadowEntity": "Book",   // This leverages the /Schema endpoint to get the record set columns.
 
-				"RecordSetListManifestOnly": true,
+				"RecordSetDashboardManifestOnly": true,
 
 				"RecordSetDashboardManifests": [ "Bestsellers", "Underdogs", "NewReleases" ],
 

--- a/source/views/dashboard/RecordSet-Dashboard.js
+++ b/source/views/dashboard/RecordSet-Dashboard.js
@@ -408,12 +408,12 @@ class viewRecordSetDashboard extends libPictRecordSetRecordView
 		{
 			// Put code here to preprocess columns into other data parts.
 			/*
-				"RecordSetListManifestOnly": false,
+				"RecordSetDashboardManifestOnly": false,
 
 				"RecordSetListManifests": [ "Bestsellers", "Underdogs", "NewReleases" ],
 				"RecordSetDashboardManifests": [ "Bestsellers" ],
 			 */
-			if (pRecordSetConfiguration.RecordSetListManifestOnly)
+			if (pRecordSetConfiguration.RecordSetDashboardManifestOnly)
 			{
 				const tmpManifestHash = pRecordSetConfiguration.RecordSetDashboardDefaultManifest || pRecordSetConfiguration.RecordSetDashboardManifests?.[0];
 				const tmpManifest = this.pict.PictSectionRecordSet.getManifest(tmpManifestHash);
@@ -509,7 +509,7 @@ class viewRecordSetDashboard extends libPictRecordSetRecordView
 			this.pict.log.error(`RecordSetDashboard: No provider found for ${pProviderHash} in ${pRecordSetConfiguration.RecordSet}.  List Render failed.`);
 			return;
 		}
-		if (pRecordSetConfiguration.RecordSetListManifestOnly)
+		if (pRecordSetConfiguration.RecordSetDashboardManifestOnly)
 		{
 			const tmpManifestHash = pRecordSetConfiguration.RecordSetDashboardDefaultManifest || pRecordSetConfiguration.RecordSetDashboardManifests?.[0];
 			const tmpManifest = this.pict.PictSectionRecordSet.getManifest(tmpManifestHash);
@@ -689,7 +689,7 @@ class viewRecordSetDashboard extends libPictRecordSetRecordView
 
 		// Put code here to preprocess columns into other data parts.
 		/*
-			"RecordSetListManifestOnly": false,
+			"RecordSetDashboardManifestOnly": false,
 
 			"RecordSetListManifests": [ "Bestsellers", "Underdogs", "NewReleases" ],
 			"RecordSetDashboardManifests": [ "Bestsellers" ],


### PR DESCRIPTION
I followed the same pattern that was being used for the dashboard manifests, but I did notice that the param that was determining whether to default to a manifest on the dashboard component was using "RecordSetListManifestOnly".
Since the existing unused configs in the examples implied the manifest list params for List and Dashboard should be separate (i.e. the examples have "RecordSetListManifests" and "RecordSetDashboardManifests") I made that paramater "RecordSetDashboardManifestOnly" for the Dashboard page and the "RecordSetListManifestOnly" for the list page.

The supported params should now be:

"RecordSetListManifestOnly" -> Whether the list page should default to a manifest.
"RecordSetListDefaultManifest" -> The hash of the manifest to default to, if not present, defaults to first manifest in the RecordSetListManifests.
"RecordSetListManifests" -> Array of List manifest Hashes.

"RecordSetDashboardManifestOnly" -> Whether the dashboard page should default to a manifest.
"RecordSetDashboardDefaultManifest" -> The hash of the manifest to default to, if not present, defaults to first manifest in the RecordSetDashboardManifests.
"RecordSetDashboardManifests" -> Array of Dashboard manifest Hashes.