### PR TITLE
Unify dashboard and list on using value templates and Add join column

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pict-section-recordset",
-  "version": "1.0.50",
+  "version": "1.0.51",
   "description": "Pict dynamic record set management views",
   "main": "source/Pict-Section-RecordSet.js",
   "directories": {

--- a/source/services/RecordsSet-MetaController.js
+++ b/source/services/RecordsSet-MetaController.js
@@ -70,12 +70,17 @@ class RecordSetMetacontroller extends libFableServiceProviderBase
 		this.pict.MetaTemplate.addPatternBoth('{~ProcessCell:', '~}', (pHash, pData, fCallback)=>
 		{ 
 			const field = this.pict.resolveStateFromAddress(pHash, pData, fCallback);
-			return fCallback(null, pData?.Payload?.[field]);
+			return fCallback(null, this.pict.manifest.getValueByHash(pData.Payload, field));
 		}, async (pHash, pData, fCallback) =>
 		{
 			const field = this.pict.resolveStateFromAddress(pHash, pData, fCallback);
-			let value = pData?.Payload?.[field];
-			const sanitizedField = field.replace('ParentID', 'ID').replace('CreatingID', 'ID').replace('DeletingID', 'ID').replace('UpdatingID', 'ID');
+			let value = this.pict.manifest.getValueByHash(pData.Payload, field);
+			const IDPrefixes = ['Parent', 'Child', 'Creating', 'Updating', 'Deleting'];
+			let sanitizedField = field;
+			for (let p of IDPrefixes)
+			{
+				sanitizedField = sanitizedField.replace(`${ p }ID`, 'ID');
+			}
 			if (sanitizedField?.startsWith('ID'))
 			{
 				if (!value)

--- a/source/services/RecordsSet-MetaController.js
+++ b/source/services/RecordsSet-MetaController.js
@@ -29,7 +29,7 @@ class RecordSetMetacontroller extends libFableServiceProviderBase
 		let tmpOptions = Object.assign({}, _DEFAULT_CONFIGURATION, pOptions);
 		super(pFable, tmpOptions, pServiceHash);
 
-		/** @type {import('pict') & { addAndInstantiateSingletonService: (hash: string, options: any, prototype: any) => any, newManyfest: (rec: any) => any }} */
+		/** @type {import('pict') & { PictSectionRecordSet: any, addAndInstantiateSingletonService: (hash: string, options: any, prototype: any) => any, newManyfest: (rec: any) => any }} */
 		this.fable;
 		this.pict = this.fable;
 		/** @type {any} */
@@ -108,6 +108,19 @@ class RecordSetMetacontroller extends libFableServiceProviderBase
 					else if (entity?.Name)
 					{
 						value = entity.Name;
+					}
+					else if (entity?.Title)
+					{
+						value = entity.Title;
+					}
+					else if (entity?.Hash)
+					{
+						value = entity.Hash;
+					}
+					if (this.pict.PictSectionRecordSet.recordSetProviderConfigurations[remote])
+					{
+						const url = this.pict.parseTemplateByHash('PRSP-Read-Link-URL-Template', { Payload: { Payload: { RecordSet: remote, GUIDAddress: `GUID${ remote }` }, Data: entity }});
+						value = `<a href="${ url }">${ value }</a>`;
 					}
 				}
 				catch (e)

--- a/source/views/dashboard/RecordSet-Dashboard-RecordListEntry.js
+++ b/source/views/dashboard/RecordSet-Dashboard-RecordListEntry.js
@@ -88,7 +88,6 @@ const _DEFAULT_CONFIGURATION_List_RecordListEntry = (
 					Template: /*html*/`
 					<li><a href="{~TBR:Record.Data.URL~}">{~TBR:Record.Data.Name~}</a></li>
 	`
-	//					{~Breakpoint~}
 
 				},
 			],

--- a/source/views/dashboard/RecordSet-Dashboard.js
+++ b/source/views/dashboard/RecordSet-Dashboard.js
@@ -195,7 +195,7 @@ class viewRecordSetDashboard extends libPictRecordSetRecordView
 						ManifestHash: 'Default',
 						PictDashboard:
 						{
-							ValueTemplate: '{~DVBK:Record.Payload:Record.Data.Key~}',
+							ValueTemplate: '{~ProcessCell:Record.Data.Key~}',
 						},
 					});
 				}
@@ -442,6 +442,10 @@ class viewRecordSetDashboard extends libPictRecordSetRecordView
 								{
 									key.ManifestHash = 'Default';
 								}
+								if (key.PictDashboard && !key.PictDashboard.ValueTemplate)
+								{
+									key.PictDashboard.ValueTemplate = '{~ProcessCell:Record.Data.Key~}';
+								}
 								return key;
 							}
 							return {
@@ -450,7 +454,7 @@ class viewRecordSetDashboard extends libPictRecordSetRecordView
 								ManifestHash: 'Default',
 								PictDashboard:
 								{
-									ValueTemplate: '{~DVBK:Record.Payload:Record.Data.Key~}',
+									ValueTemplate: '{~ProcessCell:Record.Data.Key~}',
 								},
 							};
 						});
@@ -715,7 +719,7 @@ class viewRecordSetDashboard extends libPictRecordSetRecordView
 						}
 						if (!tmpTableCell.PictDashboard.ValueTemplate)
 						{
-							tmpTableCell.PictDashboard.ValueTemplate = '{~DVBK:Record.Payload:Record.Data.Key~}';
+							tmpTableCell.PictDashboard.ValueTemplate = '{~ProcessCell:Record.Data.Key~}';
 						}
 						return tmpTableCell;
 					}
@@ -725,7 +729,7 @@ class viewRecordSetDashboard extends libPictRecordSetRecordView
 						ManifestHash: 'Default',
 						PictDashboard:
 						{
-							ValueTemplate: '{~DVBK:Record.Payload:Record.Data.Key~}',
+							ValueTemplate: '{~ProcessCell:Record.Data.Key~}',
 						},
 					};
 				});

--- a/source/views/list/RecordSet-List-RecordListEntry.js
+++ b/source/views/list/RecordSet-List-RecordListEntry.js
@@ -62,7 +62,7 @@ const _DEFAULT_CONFIGURATION_List_RecordListEntry = (
 					Hash: 'PRSP-List-RecordListEntry-Template-Row-Cell',
 					Template: /*html*/`
 		<td style="border-bottom: 1px solid #ccc; padding: 5px;">
-			{~DVBK:Record.Payload:Record.Data.Key~}
+			{~TBDA:Record.Data.PictDashboard.ValueTemplate~}
 		</td>
 	`
 				},
@@ -90,7 +90,6 @@ const _DEFAULT_CONFIGURATION_List_RecordListEntry = (
 					Template: /*html*/`
 					<li><a href="{~TBR:Record.Data.URL~}">{~TBR:Record.Data.Name~}</a></li>
 	`
-	//					{~Breakpoint~}
 
 				},
 			],

--- a/source/views/list/RecordSet-List.js
+++ b/source/views/list/RecordSet-List.js
@@ -167,6 +167,9 @@ class viewRecordSetList extends libPictRecordSetRecordView
 					pRecordListData.TableCells.push({
 						'Key': tmpColumn,
 						'DisplayName': tmpProperties?.[tmpColumn].title || tmpColumn,
+						'PictDashboard': {
+							'ValueTemplate': '{~ProcessCell:Record.Data.Key~}'
+						}
 					});
 				}
 			}
@@ -385,6 +388,13 @@ class viewRecordSetList extends libPictRecordSetRecordView
 						{
 							key.ManifestHash = 'Default';
 						}
+						if (!key.PictDashboard)
+						{
+							key.PictDashboard =
+							{
+								ValueTemplate: '{~ProcessCell:Record.Data.Key~}',
+							};
+						}
 						return key;
 					}
 					return {
@@ -393,7 +403,7 @@ class viewRecordSetList extends libPictRecordSetRecordView
 						ManifestHash: 'Default',
 						PictDashboard:
 						{
-							ValueTemplate: '{~DVBK:Record.Payload:Record.Data.Key~}',
+							ValueTemplate: '{~ProcessCell:Record.Data.Key~}',
 						},
 					};
 				});
@@ -633,6 +643,10 @@ class viewRecordSetList extends libPictRecordSetRecordView
 							{
 								key.ManifestHash = 'Default';
 							}
+							if (key.PictDashboard && !key.PictDashboard.ValueTemplate)
+							{
+								key.PictDashboard.ValueTemplate = '{~ProcessCell:Record.Data.Key~}';
+							}
 							return key;
 						}
 						return {
@@ -641,7 +655,7 @@ class viewRecordSetList extends libPictRecordSetRecordView
 							ManifestHash: 'Default',
 							PictDashboard:
 							{
-								ValueTemplate: '{~DVBK:Record.Payload:Record.Data.Key~}',
+								ValueTemplate: '{~ProcessCell:Record.Data.Key~}',
 							},
 						};
 					});


### PR DESCRIPTION
Both dashboard and list views will now use TDBA, and the list views should now default to having a "PictDashboard" object when not using a manifest so that the behavior there stays the same. 
I also added a new metatemplate pattern in the metacontroller that is now used instead of DVBK that should do mostly the same thing except for join columns it will now fetch the entity instead (if the pattern is invoked in the non async case it should just give the value)..